### PR TITLE
Fix/rollup styled failed p3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 *.tgz
+
+# storybook
+/storybook-static

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.13.3",
-        "@emotion/styled": "^11.13.0",
         "framer-motion": "^11.11.1",
         "react-i18next": "^15.0.1",
         "react-modal-sheet": "^3.1.0",
@@ -2221,6 +2220,8 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
       "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -2278,6 +2279,8 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
       "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   ],
   "dependencies": {
     "@emotion/react": "^11.13.3",
-    "@emotion/styled": "^11.13.0",
     "framer-motion": "^11.11.1",
     "react-i18next": "^15.0.1",
     "react-modal-sheet": "^3.1.0",

--- a/src/checkout/PaymentMethod.tsx
+++ b/src/checkout/PaymentMethod.tsx
@@ -1,14 +1,8 @@
-import { Box, Radio, Stack, styled } from '@mui/material';
-import {
-  Alert,
-  AlertStyle,
-  AlertType,
-  H6,
-  Lead2,
-} from '../components';
-import React from 'react';
-import { JCBIcon, MasterCardIcon, PaymentIcon, ThaiQrIcon, VisaIcon } from '../icons';
-import { Colors } from '../colors';
+import { Box, Radio, Stack } from '@mui/material'
+import { Alert, AlertStyle, AlertType, H6, Lead2 } from '../components'
+import React from 'react'
+import { JCBIcon, MasterCardIcon, PaymentIcon, ThaiQrIcon, VisaIcon } from '../icons'
+import { Colors } from '../colors'
 
 export enum EPaymentMethod {
   promptpay = 'qr_code',
@@ -21,16 +15,16 @@ export enum EPaymentMethod {
 interface EPaymentOption {
   title: string
   value: EPaymentMethod
-  image?: React.ReactNode;
+  image?: React.ReactNode
 }
 interface PaymentMethodProps {
-  onSelected?: (paymentType: EPaymentMethod) => void;
+  onSelected?: (paymentType: EPaymentMethod) => void
   paymentsOption: EPaymentOption[]
-  currentPaymentType?: EPaymentMethod;
-  title?: string;
-  hideTitle?: boolean;
-  alertText?: string;
-  withAlert?: boolean;
+  currentPaymentType?: EPaymentMethod
+  title?: string
+  hideTitle?: boolean
+  alertText?: string
+  withAlert?: boolean
 }
 
 const PaymentMethod: React.FC<PaymentMethodProps> = (props) => {
@@ -42,105 +36,85 @@ const PaymentMethod: React.FC<PaymentMethodProps> = (props) => {
     currentPaymentType,
     withAlert = false,
     hideTitle = false,
-  } = props;
-  const disabledSelect = !onSelected;
+  } = props
+  const disabledSelect = !onSelected
 
   const getPaymentIcon = (type: EPaymentMethod) => {
     switch (type) {
       case EPaymentMethod.creditCard:
         return (
-          <Stack direction={"row"} spacing={1} alignItems="center">
+          <Stack direction={'row'} spacing={1} alignItems="center">
             <VisaIcon />
             <MasterCardIcon />
             <JCBIcon />
           </Stack>
         )
       case EPaymentMethod.promptpay:
-        return (
-          <ThaiQrIcon />
-        )
+        return <ThaiQrIcon />
       default:
-        break;
+        break
     }
   }
 
   const paymentMethod = (paymentData: EPaymentOption) => {
-    if (!paymentData) return;
-    const isSelected = paymentData.value === currentPaymentType;
+    if (!paymentData) return
+    const isSelected = paymentData.value === currentPaymentType
     return (
-      <PaymentMethodItem
+      <Box
         onClick={() => !disabledSelect && onSelected(paymentData.value)}
-        className={isSelected ? 'selected' : ''}
-        style={{ cursor: disabledSelect ? 'auto' : 'pointer' }}
+        sx={{
+          boxShadow: '0px 2px 4px 0px #0000001a',
+          padding: '5px 10px',
+          borderRadius: '8px',
+          width: '100%',
+          border: isSelected ? `2px solid ${Colors.primary001}` : '1px solid #f3f6f9',
+          cursor: disabledSelect ? 'auto' : 'pointer',
+        }}
       >
-        <Box display='flex' justifyContent='space-between' alignItems='center'>
-          <Stack direction='row' alignItems='center'>
-            <Radio
-              checked={isSelected}
-              onChange={() => ''}
-              value={paymentData.value}
-              name='radio-buttons'
-            />
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Stack direction="row" alignItems="center">
+            <Radio checked={isSelected} onChange={() => ''} value={paymentData.value} name="radio-buttons" />
             <Lead2 text={paymentData.title} />
           </Stack>
           {paymentData.image ? paymentData.image : getPaymentIcon(paymentData.value)}
         </Box>
-      </PaymentMethodItem>
-    );
-  };
+      </Box>
+    )
+  }
 
   return (
-    <ContentWrapper>
-      {
-        !hideTitle && (
-          <Stack direction='row' alignItems='center' gap={'12px'}>
-            <PaymentIcon />
-            <H6 text={title} />
-          </Stack>
-        )
-      }
-      <PaymentMethodWrapper>
-        <Stack direction='column' alignItems='start' gap={'12px'}>
+    <Box
+      sx={{
+        padding: '18px',
+        backgroundColor: Colors.white,
+      }}
+    >
+      {!hideTitle && (
+        <Stack direction="row" alignItems="center" gap={'12px'}>
+          <PaymentIcon />
+          <H6 text={title} />
+        </Stack>
+      )}
+      <Box
+        sx={{
+          marginTop: '10px',
+        }}
+      >
+        <Stack direction="column" alignItems="start" gap={'12px'}>
           {paymentsOption.map((type: any) => paymentMethod(type))}
           {withAlert && (
-            <Warning>
-              <Alert
-                text={alertText}
-                type={AlertType.Info}
-                style={AlertStyle.Fill}
-                elevation={0}
-              />
-            </Warning>
+            <Box
+              sx={{
+                width: '100%',
+              }}
+            >
+              <Alert text={alertText} type={AlertType.Info} style={AlertStyle.Fill} elevation={0} />
+            </Box>
           )}
         </Stack>
-      </PaymentMethodWrapper>
-    </ContentWrapper>
-  );
-};
+      </Box>
+    </Box>
+  )
+}
 
-export default PaymentMethod;
-
-export const ContentWrapper = styled('div')`
-  padding: 18px;
-  background-color: ${Colors.white};
-`;
-
-export const PaymentMethodItem = styled('div')`
-  box-shadow: 0px 2px 4px 0px #0000001a;
-  padding: 5px 10px;
-  border-radius: 8px;
-  width: 100%;
-  border: 1px solid #f3f6f9;
-  cursor: pointer;
-  &.selected {
-    border: 2px solid ${Colors.primary001};
-  }
-`;
-
-export const PaymentMethodWrapper = styled('div')`
-  margin-top: 10px;
-`;
-
-export const Warning = styled('div')`
-  width: 100%;
-`;
+export default PaymentMethod

--- a/src/checkout/ProviderSection.tsx
+++ b/src/checkout/ProviderSection.tsx
@@ -1,24 +1,20 @@
-import { Box, Stack, styled } from '@mui/material';
-import {
-  H6,
-  Lead1,
-  P2,
-} from '../components';
-import React from 'react';
-import { ProviderAvatar } from '../components/avatar';
-import { Format } from '../utils';
-import { BGProviderIcon, ConsultIcon } from '../icons';
-import { Colors } from '../colors';
+import { Box, Stack } from '@mui/material'
+import { H6, Lead1, P2 } from '../components'
+import React from 'react'
+import { ProviderAvatar } from '../components/avatar'
+import { Format } from '../utils'
+import { BGProviderIcon, ConsultIcon } from '../icons'
+import { Colors } from '../colors'
 
 interface ProviderInfoProps {
-  positionName?: string;
-  fullName?: string;
-  netConsultationFee?: number;
-  consultationTime?: number;
-  photo?: string;
-  title?: string;
-  unitMins?: string;
-  hideTitle?: boolean;
+  positionName?: string
+  fullName?: string
+  netConsultationFee?: number
+  consultationTime?: number
+  photo?: string
+  title?: string
+  unitMins?: string
+  hideTitle?: boolean
 }
 
 const ProviderSection: React.FC<ProviderInfoProps> = (props) => {
@@ -31,70 +27,60 @@ const ProviderSection: React.FC<ProviderInfoProps> = (props) => {
     netConsultationFee = 0,
     consultationTime = 0,
     hideTitle = false,
-  } = props;
+  } = props
 
   return (
-    <ContentWrapper>
+    <Box
+      sx={{
+        padding: '18px',
+        backgroundColor: Colors.white,
+      }}
+    >
       {!hideTitle && (
-        <Stack direction='row' alignItems='center' gap={'12px'}>
+        <Stack direction="row" alignItems="center" gap={'12px'}>
           <ConsultIcon />
           <H6 text={title} />
         </Stack>
       )}
-      <ProviderDetail>
-        <ProviderInfoWrapper>
-          <Stack direction='row' alignItems='center' gap={'30px'}>
-            <ProviderAvatar imageUrl={photo} width='64px' height='64px' />
-            <Stack direction='column' alignItems='start' gap={'5px'}>
+      <Box
+        sx={{
+          position: 'relative',
+          background: 'linear-gradient(276.02deg,rgba(184, 202, 246, 0.4) 1.62%,rgba(230, 237, 255, 0.4) 89.69%)',
+          padding: '10px 14px',
+          marginTop: '10px',
+          borderRadius: '8px',
+        }}
+      >
+        <Box
+          sx={{
+            zIndex: 1,
+            position: 'relative',
+          }}
+        >
+          <Stack direction="row" alignItems="center" gap={'30px'}>
+            <ProviderAvatar imageUrl={photo} width="64px" height="64px" />
+            <Stack direction="column" alignItems="start" gap={'5px'}>
               <Lead1 text={fullName} />
               <P2 text={positionName} />
-              <Lead1
-                text={`${Format.formatPrice(netConsultationFee)}/${consultationTime} ${unitMins}`}
-              />
+              <Lead1 text={`${Format.formatPrice(netConsultationFee)}/${consultationTime} ${unitMins}`} />
             </Stack>
           </Stack>
-        </ProviderInfoWrapper>
-        <BoxAbsolute>
+        </Box>
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            right: 0,
+            padding: 0,
+            height: '82px',
+            width: '103px',
+          }}
+        >
           <BGProviderIcon height={82} />
-        </BoxAbsolute>
-      </ProviderDetail>
-    </ContentWrapper>
-  );
-};
+        </Box>
+      </Box>
+    </Box>
+  )
+}
 
-export default ProviderSection;
-
-export const ContentWrapper = styled('div')`
-  padding: 18px;
-  background-color: ${Colors.white};
-`;
-
-export const ProviderInfoWrapper = styled('div')`
-  z-index: 1;
-  position: relative;
-`;
-
-export const ProviderIconWrapper = styled('div')`
-  position: absloute;
-`;
-
-export const ProviderDetail = styled('div')`
-  position: relative;
-  background: linear-gradient(
-    276.02deg,
-    rgba(184, 202, 246, 0.4) 1.62%,
-    rgba(230, 237, 255, 0.4) 89.69%
-  );
-  padding: 10px 14px;
-  margin-top: 10px;
-  border-radius: 8px;
-`;
-
-export const BoxAbsolute = styled(Box)`
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  padding: 0;
-  height: 82px;
-  width: 103px;
-`;
+export default ProviderSection

--- a/src/components/accessCode/accessCodeForm.tsx
+++ b/src/components/accessCode/accessCodeForm.tsx
@@ -1,7 +1,9 @@
 import { Box, Paper } from '@mui/material'
 import React, { useState } from 'react'
-import { BaseText, BdPrimaryButton, TextInput } from '..'
 import { Colors } from '../../colors'
+import { BaseText } from '../font'
+import { TextInput } from '../input'
+import { BdPrimaryButton } from '../button'
 
 interface AccessCodeFormProps {
   accessCode: string

--- a/src/components/avatar/ProviderAvatar.stories.tsx
+++ b/src/components/avatar/ProviderAvatar.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from "@storybook/react";
+import ProviderAvatar, { ProviderAvatarProps } from "./ProviderAvatar";
+
+export default {
+  title: "Components/ProviderAvatar",
+  component: ProviderAvatar,
+} as Meta<typeof ProviderAvatar>;
+
+export const Default: StoryObj<ProviderAvatarProps> = {
+  args: {
+    width: "60px",
+    height: "60px",
+    imageUrl: "https://www.bdms.co.th/images/logo.png",
+    // hidIcon: false,
+    // customIcon: "Abc 123 campaign",
+  },
+};

--- a/src/components/avatar/ProviderAvatar.tsx
+++ b/src/components/avatar/ProviderAvatar.tsx
@@ -1,22 +1,25 @@
-import { styled } from '@mui/material/styles'
-import { Box } from '@mui/system';
-import { ProviderIcon } from '../../icons';
-import { Colors } from '../../colors';
+import { Box } from '@mui/system'
+import { ProviderIcon } from '../../icons'
+import { Colors } from '../../colors'
 
-interface PersonalImageProps {
-  width?: string;
-  height?: string;
-  imageUrl?: string;
+export interface ProviderAvatarProps {
+  width?: string
+  height?: string
+  imageUrl?: string
   hidIcon?: boolean
-  customIcon?: React.ReactNode;
+  customIcon?: React.ReactNode
 }
 
-const ProviderAvatar = (props: PersonalImageProps) => {
-  const { width = '50px', height = '50px', imageUrl, hidIcon = false, customIcon } = props;
+const ProviderAvatar = (props: ProviderAvatarProps) => {
+  const { width = '50px', height = '50px', imageUrl, hidIcon = false, customIcon } = props
   return (
-    <PersonalImageWrapper>
+    <Box
+      sx={{
+        position: 'relative',
+      }}
+    >
       <Box
-        component='div'
+        component="div"
         sx={{
           width,
           height,
@@ -28,24 +31,22 @@ const ProviderAvatar = (props: PersonalImageProps) => {
           position: 'relative',
         }}
       />
-      {!hidIcon && (
-        customIcon ? customIcon :
-          <ProviderIconWrapper>
+      {!hidIcon &&
+        (customIcon ? (
+          customIcon
+        ) : (
+          <Box
+            sx={{
+              position: 'absolute',
+              bottom: '-8px',
+              right: '-2px',
+            }}
+          >
             <ProviderIcon />
-          </ProviderIconWrapper>
-      )}
-    </PersonalImageWrapper>
-  );
-};
+          </Box>
+        ))}
+    </Box>
+  )
+}
 
-export default ProviderAvatar;
-
-export const PersonalImageWrapper = styled('div')`
-  position: relative;
-`;
-
-export const ProviderIconWrapper = styled('div')`
-  position: absolute;
-  bottom: -8px;
-  right: -2px;
-`;
+export default ProviderAvatar

--- a/src/components/avatar/index.ts
+++ b/src/components/avatar/index.ts
@@ -1,1 +1,2 @@
-export { default as ProviderAvatar }  from './ProviderAvatar'
+export { default as ProviderAvatar } from './ProviderAvatar'
+export type { ProviderAvatarProps } from './ProviderAvatar'


### PR DESCRIPTION
- storybook-static to gitignore
- remove @emotion/styled
- fix: The inferred type of X cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary. (change styled into Box sx)
- fix warning Circular dependencies in accessCodeForm
- add provider avatar storybook